### PR TITLE
feat(linux): use systemd user timer for suspend/reboot catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ claude-sync --status
 
 | Platform | Claude credentials | Scheduler | Install command |
 |---|---|---|---|
-| **Linux / WSL** | `~/.claude/.credentials.json` | cron | `curl \| bash` |
+| **Linux / WSL** | `~/.claude/.credentials.json` | systemd user timer *(cron fallback)* | `curl \| bash` |
 | **macOS** | macOS Keychain → file fallback | LaunchAgent | `curl \| bash` |
 | **Windows** (native) | `%USERPROFILE%\.claude\.credentials.json` | Task Scheduler | PowerShell |
+
+On Linux, the installer prefers a **systemd user timer** with `Persistent=true`, so it catches up missed runs after suspend/resume and reboot — the same feature parity the macOS LaunchAgent already provides. Systems without user systemd fall back to cron (`*/15` + `@reboot`). Plain cron does not run during suspend, so laptops should prefer the systemd path.
 
 ## Security
 
@@ -185,7 +187,10 @@ claude-sync
 # macOS — LaunchAgent (recommended, catches up after sleep)
 # Use the install script: curl ... | bash
 
-# Linux — cron
+# Linux — systemd user timer (recommended, catches up after sleep/reboot)
+# Use the install script: curl ... | bash
+
+# Linux — cron fallback (does not run during suspend)
 (crontab -l 2>/dev/null; echo "*/15 * * * * \$HOME/.local/bin/sync-claude-to-opencode.sh >> \$HOME/.local/share/opencode/sync-claude.log 2>&1") | crontab -
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,8 @@ SCRIPT_NAME="sync-claude-to-opencode.sh"
 ALIAS_NAME="claude-sync"
 REPO_RAW="https://raw.githubusercontent.com/lehdqlsl/opencode-claude-auth-sync/main"
 CRON_MARKER="# opencode-claude-auth-sync"
+SYSTEMD_SERVICE_NAME="opencode-claude-sync.service"
+SYSTEMD_TIMER_NAME="opencode-claude-sync.timer"
 
 CLAUDE_CREDS="${HOME}/.claude/.credentials.json"
 OPENCODE_AUTH="${HOME}/.local/share/opencode/auth.json"
@@ -139,21 +141,79 @@ PLIST
   echo "    Runs every 15 minutes + on login + catches up after sleep."
 
 else
-  echo "==> Setting up cron (every 15 minutes)..."
-  CRON_CMD="*/15 * * * * PATH=\"${SYNC_PATH}\" ${INSTALL_DIR}/${SCRIPT_NAME} >> ${HOME}/.local/share/opencode/sync-claude.log 2>&1 ${CRON_MARKER}"
+  # systemd user timer is the Linux equivalent of the macOS LaunchAgent above:
+  # Persistent=true catches up missed runs after sleep/resume and reboot.
+  # Cron is the fallback for systems without user systemd.
+  if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+    echo "==> Setting up systemd user timer (every 15 minutes, catches up after sleep/reboot)..."
+    SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+    LOG_PATH="${HOME}/.local/share/opencode/sync-claude.log"
 
-  if command -v crontab >/dev/null 2>&1; then
+    mkdir -p "$SYSTEMD_USER_DIR"
+    mkdir -p "$(dirname "$LOG_PATH")"
+
+    cat > "${SYSTEMD_USER_DIR}/${SYSTEMD_SERVICE_NAME}" <<SERVICE
+[Unit]
+Description=Sync Claude credentials to OpenCode
+Documentation=https://github.com/lehdqlsl/opencode-claude-auth-sync
+
+[Service]
+Type=oneshot
+Environment=PATH=${SYNC_PATH}
+ExecStart=/bin/sh -c 'exec "${INSTALL_DIR}/${SCRIPT_NAME}" >> "${LOG_PATH}" 2>&1'
+SERVICE
+
+    cat > "${SYSTEMD_USER_DIR}/${SYSTEMD_TIMER_NAME}" <<TIMER
+[Unit]
+Description=Periodic Claude -> OpenCode credential sync
+Documentation=https://github.com/lehdqlsl/opencode-claude-auth-sync
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=15min
+Persistent=true
+Unit=${SYSTEMD_SERVICE_NAME}
+
+[Install]
+WantedBy=timers.target
+TIMER
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now "$SYSTEMD_TIMER_NAME" >/dev/null
+
+    if command -v crontab >/dev/null 2>&1; then
+      EXISTING=$(crontab -l 2>/dev/null || true)
+      if echo "$EXISTING" | grep -qF "$CRON_MARKER"; then
+        FILTERED=$(echo "$EXISTING" | grep -vF "$CRON_MARKER" || true)
+        if [[ -z "$FILTERED" ]]; then
+          crontab -r 2>/dev/null || true
+        else
+          echo "$FILTERED" | crontab -
+        fi
+        echo "    Migrated legacy cron entry to systemd timer."
+      fi
+    fi
+
+    echo "    Timer registered: $SYSTEMD_TIMER_NAME"
+    echo "    Runs every 15 minutes + at boot + catches up after sleep/reboot (Persistent=true)."
+
+  elif command -v crontab >/dev/null 2>&1; then
+    echo "==> Setting up cron (every 15 minutes + @reboot)..."
+    echo "    NOTE: cron does not run while the system is suspended. On laptops, prefer systemd --user."
+    CRON_PERIODIC="*/15 * * * * PATH=\"${SYNC_PATH}\" ${INSTALL_DIR}/${SCRIPT_NAME} >> ${HOME}/.local/share/opencode/sync-claude.log 2>&1 ${CRON_MARKER}"
+    CRON_BOOT="@reboot sleep 30 && PATH=\"${SYNC_PATH}\" ${INSTALL_DIR}/${SCRIPT_NAME} >> ${HOME}/.local/share/opencode/sync-claude.log 2>&1 ${CRON_MARKER}"
+
     EXISTING=$(crontab -l 2>/dev/null || true)
     FILTERED=$(echo "$EXISTING" | grep -vF "$CRON_MARKER" || true)
     if [[ -z "$FILTERED" ]]; then
-      echo "$CRON_CMD" | crontab -
+      printf '%s\n%s\n' "$CRON_PERIODIC" "$CRON_BOOT" | crontab -
     else
-      echo "$FILTERED
-$CRON_CMD" | crontab -
+      printf '%s\n%s\n%s\n' "$FILTERED" "$CRON_PERIODIC" "$CRON_BOOT" | crontab -
     fi
-    echo "    Cron registered."
+    echo "    Cron registered (periodic every 15 min + @reboot catch-up)."
+
   else
-    echo "    WARNING: crontab not found. Set up a periodic job manually:"
+    echo "    WARNING: neither systemd --user nor crontab available. Set up a periodic job manually:"
     echo "      ${INSTALL_DIR}/${SCRIPT_NAME}"
   fi
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,6 +6,9 @@ SCRIPT_NAME="sync-claude-to-opencode.sh"
 CRON_MARKER="# opencode-claude-auth-sync"
 PLIST_NAME="com.opencode.claude-sync"
 PLIST_PATH="${HOME}/Library/LaunchAgents/${PLIST_NAME}.plist"
+SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+SYSTEMD_SERVICE_NAME="opencode-claude-sync.service"
+SYSTEMD_TIMER_NAME="opencode-claude-sync.timer"
 
 if [[ "$(uname)" == "Darwin" ]]; then
   echo "==> Removing LaunchAgent..."
@@ -17,6 +20,16 @@ if [[ "$(uname)" == "Darwin" ]]; then
     echo "    No LaunchAgent found. Skipping."
   fi
 else
+  if command -v systemctl >/dev/null 2>&1 \
+    && systemctl --user show-environment >/dev/null 2>&1 \
+    && [[ -f "${SYSTEMD_USER_DIR}/${SYSTEMD_TIMER_NAME}" || -f "${SYSTEMD_USER_DIR}/${SYSTEMD_SERVICE_NAME}" ]]; then
+    echo "==> Removing systemd user timer..."
+    systemctl --user disable --now "$SYSTEMD_TIMER_NAME" >/dev/null 2>&1 || true
+    rm -f "${SYSTEMD_USER_DIR}/${SYSTEMD_TIMER_NAME}" "${SYSTEMD_USER_DIR}/${SYSTEMD_SERVICE_NAME}"
+    systemctl --user daemon-reload 2>/dev/null || true
+    echo "    Timer removed."
+  fi
+
   echo "==> Removing cron job..."
   if command -v crontab >/dev/null 2>&1; then
     EXISTING=$(crontab -l 2>/dev/null || true)


### PR DESCRIPTION
## Problem

On Linux, the installer registers a plain `*/15 * * * *` cron job. That works fine on always-on desktops, but breaks a very common laptop workflow:

1. Close the laptop at 6pm with a valid Claude token
2. Open it at 9am the next morning → the token has expired (8-hour lifetime)
3. `cron` never fired a single `sync-claude-to-opencode.sh` during those 15 hours of suspend
4. `claude-sync` has to be run by hand before OpenCode will talk to Anthropic again

I ran into this exact pattern on Ubuntu 24.04 — `journalctl` showed the last cron `CMD` entry at 18:00:01, then `systemd-sleep` suspend at 18:03, then nothing until `resume` at 09:08 the next day. The cron entry itself is perfectly healthy; Linux cron just does not schedule work while the system is asleep and has no `Persistent=`-style catch-up on wake.

## Root Cause

Plain cron has two properties that hurt laptop users:

- **No catch-up**: a missed 18:15 run is gone. When cron comes back after resume, it only considers the next tick (09:15, up to 15 minutes after wake-up).
- **No reboot trigger**: after a full reboot, the first sync has to wait for the next 15-minute boundary.

macOS already avoids this via LaunchAgent (`RunAtLoad=true` + catch-up). Linux has the exact same capability through **systemd user timers** with `Persistent=true` and `OnBootSec=`, but the installer was not using it.

## Fix

`install.sh` now prefers a **systemd user timer** on Linux and keeps cron as a fallback:

```bash
if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
    # Write ~/.config/systemd/user/opencode-claude-sync.{service,timer}
    # systemctl --user daemon-reload && systemctl --user enable --now opencode-claude-sync.timer
elif command -v crontab >/dev/null 2>&1; then
    # Fallback: */15 cron line + a new @reboot line
else
    # Warn and bail
fi
```

The generated units:

```ini
# opencode-claude-sync.service
[Unit]
Description=Sync Claude credentials to OpenCode
Documentation=https://github.com/lehdqlsl/opencode-claude-auth-sync

[Service]
Type=oneshot
Environment=PATH=${SYNC_PATH}
ExecStart=/bin/sh -c 'exec "${INSTALL_DIR}/${SCRIPT_NAME}" >> "${LOG_PATH}" 2>&1'
```

```ini
# opencode-claude-sync.timer
[Unit]
Description=Periodic Claude -> OpenCode credential sync
Documentation=https://github.com/lehdqlsl/opencode-claude-auth-sync

[Timer]
OnBootSec=1min
OnUnitActiveSec=15min
Persistent=true
Unit=opencode-claude-sync.service

[Install]
WantedBy=timers.target
```

Key design choices:

- **`Persistent=true`**: the whole point of the PR. Missed runs fire on the next wake-up, matching the macOS LaunchAgent behavior.
- **`OnBootSec=1min`**: first sync happens ~1 minute after user session start (no 15-minute dead zone after reboot).
- **`OnUnitActiveSec=15min`**: same cadence the cron path used.
- **`ExecStart=/bin/sh -c '… >> log 2>&1'`**: keeps writing to the existing `~/.local/share/opencode/sync-claude.log` the user already knows and documents. Avoids depending on systemd 240+'s `append:` syntax, so it works on any distro that ships systemd user sessions.
- **`Environment=PATH=${SYNC_PATH}`**: reuses the same minimal PATH the installer already computes for cron / LaunchAgent (node + claude discovered at install time), so there's no new regression surface for #4 / #5.
- **Legacy cron migration**: if a previous install left a `# opencode-claude-auth-sync` cron entry, it is removed on reinstall so the two schedulers don't double-fire.

### Cron fallback improvement

For systems without user systemd (older distros, some containers, Alpine, …) the cron path now adds a `@reboot` line so at least full reboots are covered:

```cron
*/15 * * * * PATH="…" …/sync-claude-to-opencode.sh >> …/sync-claude.log 2>&1 # opencode-claude-auth-sync
@reboot sleep 30 && PATH="…" …/sync-claude-to-opencode.sh >> …/sync-claude.log 2>&1 # opencode-claude-auth-sync
```

`sleep 30` gives NetworkManager time to reattach before the OAuth refresh call. The existing `CRON_MARKER` is reused for both lines, so `grep -vF` in `install.sh` and `uninstall.sh` already picks them both up — no uninstall logic change was needed for this part.

## Impact

- **Existing cron users**: on reinstall, their `# opencode-claude-auth-sync` cron entry is auto-removed and replaced with the systemd timer. No split-brain state.
- **Existing macOS users**: untouched. The `elif Darwin` branch is unchanged.
- **`--no-scheduler`**: still skips everything, including the systemd timer.
- **No new dependencies**: systemd ships with every modern Linux distro that runs OpenCode. No curl/wget/jq additions.
- **`uninstall.sh`** is updated to `systemctl --user disable --now` the timer and clean up the unit files. The cron cleanup block is kept and naturally catches the new `@reboot` line via the same `$CRON_MARKER`.
- **README** Platform Support table now says \"systemd user timer *(cron fallback)*\" for Linux/WSL, with a short explanation of why.

## Testing

- \`bash -n install.sh\` / \`bash -n uninstall.sh\` → clean
- \`shellcheck install.sh\` / \`shellcheck uninstall.sh\` → 0 warnings
- Rendered both unit files in a sandbox \`HOME\` and ran \`systemd-analyze verify …\` → exit 0, no complaints
- Verified on Ubuntu 24.04 (systemd 255) that \`systemctl --user show-environment\` returns 0 under a normal desktop session, so the \`if\` branch is taken as expected.
- Verified that the \`Environment=PATH=\` directive is accepted by systemd user manager (the same PATH the cron path already exports, so any environment that works for cron also works here).

Happy to adjust the unit naming, the fallback \`@reboot\` sleep, or the README wording if you'd prefer something else — I tried to stay consistent with the existing macOS branch and the prior PRs (#4, #5).